### PR TITLE
Set up Sphinx documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,34 @@
+API Reference
+=============
+
+GeneralizIT Class
+-----------------
+
+.. autoclass:: generalizit.GeneralizIT
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Design Module
+-------------
+
+.. automodule:: generalizit.design
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Design Utilities
+----------------
+
+.. automodule:: generalizit.design_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+G-Theory Utilities
+------------------
+
+.. automodule:: generalizit.g_theory_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,37 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
+
+
+project = 'GeneralizIT'
+copyright = '2025, Tyler Smith'
+author = 'Tyler Smith'
+release = '0.1.2'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
+    'sphinx_autodoc_typehints',
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+.. GeneralizIT documentation master file, created by
+   sphinx-quickstart on Fri May 16 12:23:49 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to GeneralizIT's documentation!
+=======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   api
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`


### PR DESCRIPTION
This pull request introduces a new Sphinx-based documentation system for the project. It includes configuration files, build scripts, and initial content for the documentation. The changes are grouped into three main themes: build setup, configuration, and content.

### Build Setup:
* Added a `Makefile` and `make.bat` to enable building the documentation using Sphinx on Unix-like systems and Windows, respectively. These scripts include commands for generating documentation and handling errors if `sphinx-build` is not installed. [[1]](diffhunk://#diff-cdec797dddf8fc387304501d6bd4f318e1e9067c6fae012dfa8b69fd85fd3248R1-R20) [[2]](diffhunk://#diff-eced23cf23b339d5a7dcd2246cb8fb515b1fa640975b585950c75ae19ba55febR1-R35)

### Configuration:
* Created a `conf.py` file to configure Sphinx, specifying project metadata (e.g., project name, author, version), extensions (e.g., `autodoc`, `viewcode`), and output options (e.g., HTML theme).

### Content:
* Added `index.rst` as the root of the documentation, with a table of contents linking to the API reference.
* Created `api.rst` to document the `GeneralizIT` class and its modules (`design`, `design_utils`, `g_theory_utils`) using Sphinx directives like `autoclass` and `automodule`.